### PR TITLE
feature: add support for fetching committee fundraising details

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a Go client for the [OpenSecrets campaign finance API.](https://www.open
 | candIndustry      | GetCandidateIndustries   | :heavy_check_mark:      |
 | candIndByInd      | GetCandidateIndustryDetails | :heavy_check_mark:   |
 | candSector        | GetCandidateTopSectorDetails | :heavy_check_mark:   |
-| congCmteIndus     |                          | TODO   |
+| congCmteIndus     | GetCommitteeFundraisingDetails | :heavy_check_mark:   |
 | getOrgs           |                          | TODO   |
 | orgSummary        |                          | TODO   |
 | independentExpend |                          | TODO   |

--- a/internal/mocks/mockFundraisingByCommitteeResponse.json
+++ b/internal/mocks/mockFundraisingByCommitteeResponse.json
@@ -1,0 +1,632 @@
+{
+    "response": {
+        "committee": {
+            "@attributes": {
+                "committee_name": "HARM",
+                "industry": "Real Estate",
+                "congno": "116",
+                "origin": "Center for Responsive Politics",
+                "source": "https://www.opensecrets.org/cong-cmtes/profiles?cmte=HARM&congno=116",
+                "last_updated": "03/22/21"
+            },
+            "member": [
+                {
+                    "@attributes": {
+                        "member_name": "Stefanik, Elise",
+                        "cid": "N00035523",
+                        "party": "R",
+                        "state": "New York",
+                        "total": "402408",
+                        "indivs": "375408",
+                        "pacs": "27000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Slotkin, Elissa",
+                        "cid": "N00041357",
+                        "party": "D",
+                        "state": "Michigan",
+                        "total": "320497",
+                        "indivs": "314497",
+                        "pacs": "6000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Gabbard, Tulsi",
+                        "cid": "N00033281",
+                        "party": "D",
+                        "state": "",
+                        "total": "304212",
+                        "indivs": "304212",
+                        "pacs": "0"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Kim, Andy",
+                        "cid": "N00041370",
+                        "party": "D",
+                        "state": "New Jersey",
+                        "total": "281510",
+                        "indivs": "266010",
+                        "pacs": "15500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Sherrill, Mikie",
+                        "cid": "N00041154",
+                        "party": "D",
+                        "state": "New Jersey",
+                        "total": "251947",
+                        "indivs": "231447",
+                        "pacs": "20500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Luria, Elaine",
+                        "cid": "N00042293",
+                        "party": "D",
+                        "state": "Virginia",
+                        "total": "249179",
+                        "indivs": "242179",
+                        "pacs": "7000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Small, Xochitl Torres",
+                        "cid": "N00042467",
+                        "party": "D",
+                        "state": "New Mexico",
+                        "total": "230987",
+                        "indivs": "210987",
+                        "pacs": "20000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Crow, Jason",
+                        "cid": "N00040876",
+                        "party": "D",
+                        "state": "Colorado",
+                        "total": "187733",
+                        "indivs": "178733",
+                        "pacs": "9000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Cheney, Liz",
+                        "cid": "N00035504",
+                        "party": "R",
+                        "state": "Wyoming",
+                        "total": "183843",
+                        "indivs": "139843",
+                        "pacs": "44000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Horn, Kendra",
+                        "cid": "N00041394",
+                        "party": "D",
+                        "state": "Oklahoma",
+                        "total": "167558",
+                        "indivs": "155558",
+                        "pacs": "12000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Byrne, Bradley",
+                        "cid": "N00035380",
+                        "party": "R",
+                        "state": "Alabama",
+                        "total": "160073",
+                        "indivs": "144073",
+                        "pacs": "16000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Cisneros, Gil",
+                        "cid": "N00041464",
+                        "party": "D",
+                        "state": "California",
+                        "total": "139347",
+                        "indivs": "129347",
+                        "pacs": "10000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Bacon, Donald John",
+                        "cid": "N00037049",
+                        "party": "R",
+                        "state": "Nebraska",
+                        "total": "133812",
+                        "indivs": "108312",
+                        "pacs": "25500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Wittman, Rob",
+                        "cid": "N00029459",
+                        "party": "R",
+                        "state": "Virginia",
+                        "total": "132842",
+                        "indivs": "122342",
+                        "pacs": "10500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Moulton, Seth",
+                        "cid": "N00035431",
+                        "party": "D",
+                        "state": "Massachusetts",
+                        "total": "123728",
+                        "indivs": "117228",
+                        "pacs": "6500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Norcross, Don",
+                        "cid": "N00036154",
+                        "party": "D",
+                        "state": "New Jersey",
+                        "total": "120791",
+                        "indivs": "97291",
+                        "pacs": "23500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Gallagher, Mike",
+                        "cid": "N00039330",
+                        "party": "R",
+                        "state": "Wisconsin",
+                        "total": "119301",
+                        "indivs": "108801",
+                        "pacs": "10500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Golden, Jared",
+                        "cid": "N00041668",
+                        "party": "D",
+                        "state": "Maine",
+                        "total": "115225",
+                        "indivs": "109225",
+                        "pacs": "6000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Bergman, John",
+                        "cid": "N00039533",
+                        "party": "R",
+                        "state": "Michigan",
+                        "total": "114920",
+                        "indivs": "96420",
+                        "pacs": "18500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Houlahan, Chrissy",
+                        "cid": "N00040949",
+                        "party": "D",
+                        "state": "Pennsylvania",
+                        "total": "102366",
+                        "indivs": "81366",
+                        "pacs": "21000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Turner, Michael R",
+                        "cid": "N00025175",
+                        "party": "R",
+                        "state": "Ohio",
+                        "total": "96409",
+                        "indivs": "86409",
+                        "pacs": "10000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Khanna, Ro",
+                        "cid": "N00026427",
+                        "party": "D",
+                        "state": "California",
+                        "total": "84334",
+                        "indivs": "84334",
+                        "pacs": "0"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Wilson, Joe",
+                        "cid": "N00024809",
+                        "party": "R",
+                        "state": "South Carolina",
+                        "total": "83320",
+                        "indivs": "71820",
+                        "pacs": "11500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Trahan, Lori",
+                        "cid": "N00041808",
+                        "party": "D",
+                        "state": "Massachusetts",
+                        "total": "79404",
+                        "indivs": "77404",
+                        "pacs": "2000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Gaetz, Matt",
+                        "cid": "N00039503",
+                        "party": "R",
+                        "state": "Florida",
+                        "total": "78537",
+                        "indivs": "77537",
+                        "pacs": "1000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Carbajal, Salud",
+                        "cid": "N00037015",
+                        "party": "D",
+                        "state": "California",
+                        "total": "76634",
+                        "indivs": "69634",
+                        "pacs": "7000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Brown, Anthony",
+                        "cid": "N00036999",
+                        "party": "D",
+                        "state": "Maryland",
+                        "total": "72397",
+                        "indivs": "54897",
+                        "pacs": "17500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Hill, Katie",
+                        "cid": "N00040644",
+                        "party": "D",
+                        "state": "California",
+                        "total": "67978",
+                        "indivs": "66978",
+                        "pacs": "1000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Waltz, Michael",
+                        "cid": "N00042403",
+                        "party": "R",
+                        "state": "Florida",
+                        "total": "62780",
+                        "indivs": "55780",
+                        "pacs": "7000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Garamendi, John",
+                        "cid": "N00030856",
+                        "party": "D",
+                        "state": "California",
+                        "total": "61020",
+                        "indivs": "46520",
+                        "pacs": "14500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Hartzler, Vicky",
+                        "cid": "N00031005",
+                        "party": "R",
+                        "state": "Missouri",
+                        "total": "60447",
+                        "indivs": "53447",
+                        "pacs": "7000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Escobar, Veronica",
+                        "cid": "N00041702",
+                        "party": "D",
+                        "state": "Texas",
+                        "total": "60018",
+                        "indivs": "46018",
+                        "pacs": "14000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Rogers, Mike D",
+                        "cid": "N00024759",
+                        "party": "R",
+                        "state": "Alabama",
+                        "total": "56000",
+                        "indivs": "40000",
+                        "pacs": "16000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Cooper, Jim",
+                        "cid": "N00003132",
+                        "party": "D",
+                        "state": "Tennessee",
+                        "total": "55800",
+                        "indivs": "40800",
+                        "pacs": "15000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Gallego, Ruben",
+                        "cid": "N00036097",
+                        "party": "D",
+                        "state": "Arizona",
+                        "total": "53432",
+                        "indivs": "33932",
+                        "pacs": "19500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Brooks, Mo",
+                        "cid": "N00030910",
+                        "party": "R",
+                        "state": "Alabama",
+                        "total": "49680",
+                        "indivs": "38680",
+                        "pacs": "11000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Graves, Sam",
+                        "cid": "N00013323",
+                        "party": "R",
+                        "state": "Missouri",
+                        "total": "47620",
+                        "indivs": "17620",
+                        "pacs": "30000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Banks, Jim",
+                        "cid": "N00037185",
+                        "party": "R",
+                        "state": "Indiana",
+                        "total": "42533",
+                        "indivs": "24533",
+                        "pacs": "18000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Speier, Jackie",
+                        "cid": "N00029649",
+                        "party": "D",
+                        "state": "California",
+                        "total": "41602",
+                        "indivs": "32102",
+                        "pacs": "9500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Haaland, Debra",
+                        "cid": "N00040933",
+                        "party": "D",
+                        "state": "New Mexico",
+                        "total": "39469",
+                        "indivs": "32469",
+                        "pacs": "7000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Smith, Adam",
+                        "cid": "N00007833",
+                        "party": "D",
+                        "state": "Washington",
+                        "total": "36850",
+                        "indivs": "23850",
+                        "pacs": "13000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Langevin, Jim",
+                        "cid": "N00009724",
+                        "party": "D",
+                        "state": "Rhode Island",
+                        "total": "29913",
+                        "indivs": "21913",
+                        "pacs": "8000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Keating, Bill",
+                        "cid": "N00031933",
+                        "party": "D",
+                        "state": "Massachusetts",
+                        "total": "27681",
+                        "indivs": "14681",
+                        "pacs": "13000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Larsen, Rick",
+                        "cid": "N00009759",
+                        "party": "D",
+                        "state": "Washington",
+                        "total": "19985",
+                        "indivs": "10485",
+                        "pacs": "9500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Courtney, Joe",
+                        "cid": "N00024842",
+                        "party": "D",
+                        "state": "Connecticut",
+                        "total": "18675",
+                        "indivs": "8175",
+                        "pacs": "10500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Lamborn, Douglas L",
+                        "cid": "N00028133",
+                        "party": "R",
+                        "state": "Colorado",
+                        "total": "18000",
+                        "indivs": "8500",
+                        "pacs": "9500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Kelly, Trent",
+                        "cid": "N00037003",
+                        "party": "R",
+                        "state": "Mississippi",
+                        "total": "17408",
+                        "indivs": "7908",
+                        "pacs": "9500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Thornberry, Mac",
+                        "cid": "N00006052",
+                        "party": "R",
+                        "state": "Texas",
+                        "total": "17250",
+                        "indivs": "16250",
+                        "pacs": "1000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Scott, Austin",
+                        "cid": "N00032457",
+                        "party": "R",
+                        "state": "Georgia",
+                        "total": "16650",
+                        "indivs": "10650",
+                        "pacs": "6000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Vela, Filemon",
+                        "cid": "N00034349",
+                        "party": "D",
+                        "state": "Texas",
+                        "total": "15000",
+                        "indivs": "0",
+                        "pacs": "15000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Cook, Paul",
+                        "cid": "N00034224",
+                        "party": "R",
+                        "state": "California",
+                        "total": "11953",
+                        "indivs": "10953",
+                        "pacs": "1000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Desjarlais, Scott",
+                        "cid": "N00030957",
+                        "party": "R",
+                        "state": "Tennessee",
+                        "total": "9000",
+                        "indivs": "3000",
+                        "pacs": "6000"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Mitchell, Paul",
+                        "cid": "N00036274",
+                        "party": "R",
+                        "state": "Michigan",
+                        "total": "4000",
+                        "indivs": "2500",
+                        "pacs": "1500"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Conaway, Mike",
+                        "cid": "N00026041",
+                        "party": "R",
+                        "state": "Texas",
+                        "total": "4000",
+                        "indivs": "4000",
+                        "pacs": "0"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Davis, Susan",
+                        "cid": "N00009604",
+                        "party": "D",
+                        "state": "California",
+                        "total": "1025",
+                        "indivs": "1025",
+                        "pacs": "0"
+                    }
+                },
+                {
+                    "@attributes": {
+                        "member_name": "Abraham, Ralph",
+                        "cid": "N00036633",
+                        "party": "R",
+                        "state": "Louisiana",
+                        "total": "1000",
+                        "indivs": "0",
+                        "pacs": "1000"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -213,3 +213,31 @@ func ParseCandidateTopSectorsJSON(jsonBody []byte) (models.CandidateTopSectorDet
 
 	return details, nil
 }
+
+func ParseFundraisingByCommitteeJSON(jsonBody []byte) (models.CommitteeFundraisingDetails, error) {
+	type fundraisingByCommitteeResponse struct {
+		Response struct {
+			Wrapper struct {
+				CommitteeDetails models.CommitteeFundraisingDetails `json:"@attributes"`
+				MemberList       []struct {
+					Member models.CommitteeMember `json:"@attributes"`
+				} `json:"member"`
+			} `json:"committee"`
+		} `json:"response"`
+	}
+
+	var responseWrapper fundraisingByCommitteeResponse
+	err := json.Unmarshal(jsonBody, &responseWrapper)
+
+	if err != nil {
+		return models.CommitteeFundraisingDetails{}, errors.New(UnableToParseErrorMessage)
+	}
+
+	details := responseWrapper.Response.Wrapper.CommitteeDetails
+
+	for _, member := range responseWrapper.Response.Wrapper.MemberList {
+		details.Members = append(details.Members, member.Member)
+	}
+
+	return details, nil
+}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -212,3 +212,31 @@ func TestParseCandidateTopSectorsJSON(t *testing.T) {
 		test.AssertErrorMessage(err, UnableToParseErrorMessage, t)
 	})
 }
+
+func TestParseFundraisingByCommitteeJSON(t *testing.T) {
+	t.Run("Correctly parses valid JSON", func(t *testing.T) {
+		json, err := ioutil.ReadFile("../mocks/mockFundraisingByCommitteeResponse.json")
+		test.AssertNoError(err, t)
+
+		details, err := ParseFundraisingByCommitteeJSON(json)
+		test.AssertNoError(err, t)
+
+		test.AssertStringMatches(details.Industry, "Real Estate", t)
+		test.AssertIntMatches(details.CongressNumber, 116, t)
+
+		test.AssertSliceLength(len(details.Members), 56, t)
+
+		firstMember := details.Members[0]
+
+		test.AssertStringMatches(firstMember.Name, "Stefanik, Elise", t)
+		expectedTotal := float64(402408)
+		if firstMember.Total != expectedTotal {
+			t.Errorf("Got float %f wanted %f", firstMember.Total, expectedTotal)
+		}
+	})
+	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
+		json := []byte(`GARBAGE`)
+		_, err := ParseFundraisingByCommitteeJSON(json)
+		test.AssertErrorMessage(err, UnableToParseErrorMessage, t)
+	})
+}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -117,10 +117,7 @@ func TestParseCandidateContributorsJSON(t *testing.T) {
 
 		expectedFirstContributorTotal := float64(130682)
 
-		if firstContributor.Total != expectedFirstContributorTotal {
-			t.Errorf("Got float %f wanted %f", firstContributor.Total, expectedFirstContributorTotal)
-		}
-
+		test.AssertFloat64Matches(firstContributor.Total, expectedFirstContributorTotal, t)
 	})
 	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
 		json := []byte(`GARBAGE`)
@@ -148,9 +145,7 @@ func TestParseCandidateIndustriesJSON(t *testing.T) {
 		test.AssertStringMatches(topIndustry.IndustryName, expectedIndustryName, t)
 
 		expectedTotal := float64(312081)
-		if topIndustry.Total != expectedTotal {
-			t.Errorf("Got float %f wanted %f", topIndustry.Total, expectedTotal)
-		}
+		test.AssertFloat64Matches(topIndustry.Total, expectedTotal, t)
 	})
 	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
 		json := []byte(`GARBAGE`)
@@ -171,9 +166,7 @@ func TestParseCandidateIndustryDetailsJSON(t *testing.T) {
 		test.AssertStringMatches(details.Chamber, expectedChamber, t)
 
 		expectedTotal := float64(151248)
-		if details.Total != expectedTotal {
-			t.Errorf("Got float %f wanted %f", details.Total, expectedTotal)
-		}
+		test.AssertFloat64Matches(details.Total, expectedTotal, t)
 	})
 	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
 		json := []byte(`GARBAGE`)
@@ -201,10 +194,7 @@ func TestParseCandidateTopSectorsJSON(t *testing.T) {
 		test.AssertStringMatches(firstSector.Id, expectedSectorId, t)
 
 		expectedSectorIndividuals := float64(125816)
-		if firstSector.Individuals != expectedSectorIndividuals {
-			t.Errorf("Got float %f wanted %f", firstSector.Individuals, expectedSectorIndividuals)
-		}
-
+		test.AssertFloat64Matches(firstSector.Individuals, expectedSectorIndividuals, t)
 	})
 	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
 		json := []byte(`GARBAGE`)
@@ -230,9 +220,7 @@ func TestParseFundraisingByCommitteeJSON(t *testing.T) {
 
 		test.AssertStringMatches(firstMember.Name, "Stefanik, Elise", t)
 		expectedTotal := float64(402408)
-		if firstMember.Total != expectedTotal {
-			t.Errorf("Got float %f wanted %f", firstMember.Total, expectedTotal)
-		}
+		test.AssertFloat64Matches(firstMember.Total, expectedTotal, t)
 	})
 	t.Run("Returns an error for invalid JSON", func(t *testing.T) {
 		json := []byte(`GARBAGE`)

--- a/internal/test/test_helpers.go
+++ b/internal/test/test_helpers.go
@@ -38,6 +38,13 @@ func AssertIntMatches(got, wanted int, t *testing.T) {
 	}
 }
 
+func AssertFloat64Matches(got, wanted float64, t *testing.T) {
+	t.Helper()
+	if got != wanted {
+		t.Errorf("Got float %f wanted %f", got, wanted)
+	}
+}
+
 func AssertSliceLength(got, wanted int, t *testing.T) {
 	t.Helper()
 	if got != wanted {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,25 +23,25 @@ An OpenSecretsClient is thread safe and you should use/share one throughout your
 type OpenSecretsClient interface {
 	// Provides a list of Congressional legislators for a specified subset (state or specific CID)
 	// https://www.opensecrets.org/api/?method=getLegislators&output=doc
-	GetLegislators(request models.GetLegislatorsRequest) ([]models.Legislator, error)
+	GetLegislators(request models.LegislatorsRequest) ([]models.Legislator, error)
 	// Returns data on the personal finances of a member of Congress, as well as judicial + executive branches
 	// https://www.opensecrets.org/api/?method=memPFDprofile&output=doc
-	GetMemberPFDProfile(request models.GetMemberPFDRequest) (models.MemberProfile, error)
+	GetMemberPFDProfile(request models.MemberPFDRequest) (models.MemberProfile, error)
 	// Provides summary fundraising information for a politician
 	// https://www.opensecrets.org/api/?method=candSummary&output=doc
-	GetCandidateSummary(request models.GetCandidateSummaryRequest) (models.CandidateSummary, error)
+	GetCandidateSummary(request models.CandidateSummaryRequest) (models.CandidateSummary, error)
 	// Returns top contributors to a candidate for/sitting member of Congress
 	// https://www.opensecrets.org/api/?method=candContrib&output=doc
-	GetCandidateContributors(request models.GetCandidateContributorsRequest) (models.CandidateContributorSummary, error)
+	GetCandidateContributors(request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error)
 	// Provides the top 10 industries contributing to a candidate
 	// https://www.opensecrets.org/api/?method=candIndustry&output=doc
-	GetCandidateIndustries(request models.GetCandidateIndustriesRequest) (models.CandidateIndustriesSummary, error)
+	GetCandidateIndustries(request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error)
 	// Provides total contributed to a candidate from an industry.
 	// https://www.opensecrets.org/api/?method=candIndByInd&output=doc
-	GetCandidateIndustryDetails(request models.GetCandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error)
+	GetCandidateIndustryDetails(request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error)
 	// Provides sector total of a candidate's receipts
 	// https://www.opensecrets.org/api/?method=candSector&output=doc
-	GetCandidateTopSectorDetails(request models.GetCandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error)
+	GetCandidateTopSectorDetails(request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error)
 	// Provides fundraising details for all members of a given committee from the provided industry
 	// https://www.opensecrets.org/api/?method=congCmteIndus&output=doc
 	GetCommitteeFundraisingDetails(request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error)
@@ -78,7 +78,7 @@ func NewOpenSecretsClientWithHttpClient(apikey string, client OpenSecretsHttpCli
 	return &openSecretsClient{apiKey: apikey, client: client, validator: validator.New()}
 }
 
-func (o *openSecretsClient) GetLegislators(request models.GetLegislatorsRequest) ([]models.Legislator, error) {
+func (o *openSecretsClient) GetLegislators(request models.LegislatorsRequest) ([]models.Legislator, error) {
 
 	err := o.validator.Struct(request)
 
@@ -96,7 +96,7 @@ func (o *openSecretsClient) GetLegislators(request models.GetLegislatorsRequest)
 	return parse.ParseGetLegislatorsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetMemberPFDProfile(request models.GetMemberPFDRequest) (models.MemberProfile, error) {
+func (o *openSecretsClient) GetMemberPFDProfile(request models.MemberPFDRequest) (models.MemberProfile, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -114,7 +114,7 @@ func (o *openSecretsClient) GetMemberPFDProfile(request models.GetMemberPFDReque
 	return parse.ParseMemberPFDJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateSummary(request models.GetCandidateSummaryRequest) (models.CandidateSummary, error) {
+func (o *openSecretsClient) GetCandidateSummary(request models.CandidateSummaryRequest) (models.CandidateSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -132,7 +132,7 @@ func (o *openSecretsClient) GetCandidateSummary(request models.GetCandidateSumma
 	return parse.ParseCandidateSummaryJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateContributors(request models.GetCandidateContributorsRequest) (models.CandidateContributorSummary, error) {
+func (o *openSecretsClient) GetCandidateContributors(request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -150,7 +150,7 @@ func (o *openSecretsClient) GetCandidateContributors(request models.GetCandidate
 	return parse.ParseCandidateContributorsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateIndustries(request models.GetCandidateIndustriesRequest) (models.CandidateIndustriesSummary, error) {
+func (o *openSecretsClient) GetCandidateIndustries(request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -168,7 +168,7 @@ func (o *openSecretsClient) GetCandidateIndustries(request models.GetCandidateIn
 	return parse.ParseCandidateIndustriesJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateIndustryDetails(request models.GetCandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error) {
+func (o *openSecretsClient) GetCandidateIndustryDetails(request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -186,7 +186,7 @@ func (o *openSecretsClient) GetCandidateIndustryDetails(request models.GetCandid
 	return parse.ParseCandidateIndustryDetailsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.GetCandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error) {
+func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,6 +42,9 @@ type OpenSecretsClient interface {
 	// Provides sector total of a candidate's receipts
 	// https://www.opensecrets.org/api/?method=candSector&output=doc
 	GetCandidateTopSectorDetails(request models.GetCandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error)
+	// Provides fundraising details for all members of a given committee from the provided industry
+	// https://www.opensecrets.org/api/?method=congCmteIndus&output=doc
+	GetCommitteeFundraisingDetails(request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error)
 }
 
 /*
@@ -199,6 +202,24 @@ func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.GetCandi
 	}
 
 	return parse.ParseCandidateTopSectorsJSON(responseBody)
+}
+
+func (o *openSecretsClient) GetCommitteeFundraisingDetails(request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error) {
+	err := o.validator.Struct(request)
+
+	if err != nil {
+		return models.CommitteeFundraisingDetails{}, err
+	}
+
+	url := buildFundraisingByCongressionalCommitteeRequestURL(request, o.apiKey)
+
+	responseBody, err := o.makeGETRequest(url)
+
+	if err != nil {
+		return models.CommitteeFundraisingDetails{}, err
+	}
+
+	return parse.ParseFundraisingByCommitteeJSON(responseBody)
 }
 
 func (o *openSecretsClient) makeGETRequest(url string) ([]byte, error) {

--- a/pkg/client/client_integration_test.go
+++ b/pkg/client/client_integration_test.go
@@ -26,7 +26,7 @@ func TestClientEndToEnd(t *testing.T) {
 	client := NewOpenSecretsClientWithHttpClient(apiKey, httpClient)
 
 	t.Run("GetLegislators", func(t *testing.T) {
-		request := models.GetLegislatorsRequest{Id: "TX"}
+		request := models.LegislatorsRequest{Id: "TX"}
 		legislators, err := client.GetLegislators(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetLegislators", err.Error())
@@ -39,7 +39,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetMemberPFDProfile", func(t *testing.T) {
-		request := models.GetMemberPFDRequest{Cid: "N00007360", Year: 2016}
+		request := models.MemberPFDRequest{Cid: "N00007360", Year: 2016}
 
 		memberProfile, err := client.GetMemberPFDProfile(request)
 
@@ -67,7 +67,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetCandidateSummary", func(t *testing.T) {
-		request := models.GetCandidateSummaryRequest{Cid: "N00007360", Cycle: 2022}
+		request := models.CandidateSummaryRequest{Cid: "N00007360", Cycle: 2022}
 		candidateSummary, err := client.GetCandidateSummary(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateSummary", err.Error())
@@ -79,7 +79,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetCandidateContributors", func(t *testing.T) {
-		request := models.GetCandidateContributorsRequest{Cid: "N00007360", Cycle: 2018}
+		request := models.CandidateContributorsRequest{Cid: "N00007360", Cycle: 2018}
 		candidateContributorSummary, err := client.GetCandidateContributors(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateContributors", err.Error())
@@ -90,7 +90,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetCandidateIndustries", func(t *testing.T) {
-		request := models.GetCandidateIndustriesRequest{Cid: "N00005681", Cycle: 2018}
+		request := models.CandidateIndustriesRequest{Cid: "N00005681", Cycle: 2018}
 		summary, err := client.GetCandidateIndustries(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateIndustries", err.Error())
@@ -101,7 +101,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetCandidateIndustryDetails", func(t *testing.T) {
-		request := models.GetCandidateIndustryDetailsRequest{Cid: "N00007360", Ind: "K02", Cycle: 2020}
+		request := models.CandidateIndustryDetailsRequest{Cid: "N00007360", Ind: "K02", Cycle: 2020}
 		details, err := client.GetCandidateIndustryDetails(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateIndustryDetails", err.Error())
@@ -113,7 +113,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetCandidateTopSectorDetails", func(t *testing.T) {
-		request := models.GetCandidateTopSectorsRequest{Cid: "N00007360", Cycle: 2020}
+		request := models.CandidateTopSectorsRequest{Cid: "N00007360", Cycle: 2020}
 		details, err := client.GetCandidateTopSectorDetails(request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateTopSectorDetails", err.Error())

--- a/pkg/client/client_integration_test.go
+++ b/pkg/client/client_integration_test.go
@@ -130,4 +130,19 @@ func TestClientEndToEnd(t *testing.T) {
 		test.AssertFloat64Matches(firstSector.Individuals, expectedSectorIndividuals, t)
 	})
 
+	t.Run("GetCommitteeFundraisingDetails", func(t *testing.T) {
+		request := models.FundraisingByCongressionalCommitteeRequest{Committee: "HARM", Industry: "F10", CongressNumber: 116}
+		details, err := client.GetCommitteeFundraisingDetails(request)
+		if err != nil {
+			t.Fatalf("Got error %s when calling GetCommitteeFundraisingDetails", err.Error())
+		}
+
+		test.AssertStringMatches(details.CommitteeName, "HARM", t)
+		test.AssertSliceLength(len(details.Members), 56, t)
+
+		firstMember := details.Members[0]
+		test.AssertStringMatches(firstMember.State, "New York", t)
+		test.AssertFloat64Matches(firstMember.Pacs, float64(27000), t)
+	})
+
 }

--- a/pkg/client/client_integration_test.go
+++ b/pkg/client/client_integration_test.go
@@ -109,9 +109,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 		test.AssertStringMatches(details.Chamber, "H", t)
 		expectedTotal := float64(151248)
-		if details.Total != expectedTotal {
-			t.Errorf("Got float %f wanted %f", details.Total, expectedTotal)
-		}
+		test.AssertFloat64Matches(details.Total, expectedTotal, t)
 	})
 
 	t.Run("GetCandidateTopSectorDetails", func(t *testing.T) {
@@ -129,10 +127,7 @@ func TestClientEndToEnd(t *testing.T) {
 		test.AssertStringMatches(firstSector.Id, expectedSectorId, t)
 
 		expectedSectorIndividuals := float64(125816)
-		if firstSector.Individuals != expectedSectorIndividuals {
-			t.Errorf("Got float %f wanted %f", firstSector.Individuals, expectedSectorIndividuals)
-		}
-
+		test.AssertFloat64Matches(firstSector.Individuals, expectedSectorIndividuals, t)
 	})
 
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -32,7 +32,7 @@ func (m *mockValidator) Struct(s interface{}) error {
 func TestGetLegislators(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetLegislatorsRequest{}
+		request := models.LegislatorsRequest{}
 		_, err := client.GetLegislators(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -41,7 +41,7 @@ func TestGetLegislators(t *testing.T) {
 func TestGetMemberPFDProfile(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetMemberPFDRequest{Year: 2020}
+		request := models.MemberPFDRequest{Year: 2020}
 		_, err := client.GetMemberPFDProfile(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -50,7 +50,7 @@ func TestGetMemberPFDProfile(t *testing.T) {
 func TestGetCandidateSummary(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateSummaryRequest{Cycle: 2022}
+		request := models.CandidateSummaryRequest{Cycle: 2022}
 		_, err := client.GetCandidateSummary(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -59,7 +59,7 @@ func TestGetCandidateSummary(t *testing.T) {
 func TestGetCandidateContributors(t *testing.T) {
 	t.Run("Returns an error if the request passed is invaid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateContributorsRequest{}
+		request := models.CandidateContributorsRequest{}
 		_, err := client.GetCandidateContributors(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -68,7 +68,7 @@ func TestGetCandidateContributors(t *testing.T) {
 func TestGetCandidateIndustries(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateIndustriesRequest{}
+		request := models.CandidateIndustriesRequest{}
 		_, err := client.GetCandidateIndustries(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -77,13 +77,13 @@ func TestGetCandidateIndustries(t *testing.T) {
 func TestGetCandidateIndustryDetails(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have a CID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateIndustryDetailsRequest{Ind: "K02"}
+		request := models.CandidateIndustryDetailsRequest{Ind: "K02"}
 		_, err := client.GetCandidateIndustryDetails(request)
 		test.AssertErrorExists(err, t)
 	})
 	t.Run("Returns an error if the request doesn't have an industry code", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateIndustryDetailsRequest{Cid: "N00007360"}
+		request := models.CandidateIndustryDetailsRequest{Cid: "N00007360"}
 		_, err := client.GetCandidateIndustryDetails(request)
 		test.AssertErrorExists(err, t)
 
@@ -93,7 +93,7 @@ func TestGetCandidateIndustryDetails(t *testing.T) {
 func TestGetCandidateTopSectorDetails(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have a CID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
-		request := models.GetCandidateTopSectorsRequest{}
+		request := models.CandidateTopSectorsRequest{}
 		_, err := client.GetCandidateTopSectorDetails(request)
 		test.AssertErrorExists(err, t)
 	})
@@ -118,14 +118,14 @@ func TestMakeGETRequest(t *testing.T) {
 	t.Run("Returns an error if the HTTP call fails", func(t *testing.T) {
 		mockError := errors.New("fail")
 		client := openSecretsClient{client: &mockHttpClient{mockError: mockError}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.GetLegislatorsRequest{})
+		_, err := client.GetLegislators(models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		test.AssertErrorMessage(err, "fail", t)
 	})
 	t.Run("Returns an error if the HTTP call is a >= 400 status code", func(t *testing.T) {
 		mockResponse := buildMockResponse(400, "")
 		client := openSecretsClient{client: &mockHttpClient{mockResponse: mockResponse}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.GetLegislatorsRequest{})
+		_, err := client.GetLegislators(models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		wantedErrorMessage := "received 400 status code calling OpenSecrets API"
 		test.AssertErrorMessage(err, wantedErrorMessage, t)
@@ -133,7 +133,7 @@ func TestMakeGETRequest(t *testing.T) {
 	t.Run("Returns an error if the response body can't be parsed", func(t *testing.T) {
 		mockResponse := buildMockResponse(200, `BAD JSON WEEEE`)
 		client := openSecretsClient{client: &mockHttpClient{mockResponse: mockResponse}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.GetLegislatorsRequest{})
+		_, err := client.GetLegislators(models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		wantedErrorMessage := parse.UnableToParseErrorMessage
 		test.AssertErrorMessage(err, wantedErrorMessage, t)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -99,6 +99,21 @@ func TestGetCandidateTopSectorDetails(t *testing.T) {
 	})
 }
 
+func TestGetCommitteeFundraisingDetails(t *testing.T) {
+	t.Run("Returns an error if the request doesn't have a committee ID", func(t *testing.T) {
+		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
+		request := models.FundraisingByCongressionalCommitteeRequest{Industry: "ABC"}
+		_, err := client.GetCommitteeFundraisingDetails(request)
+		test.AssertErrorExists(err, t)
+	})
+	t.Run("Returns an error if the request doesn't have an industry ID", func(t *testing.T) {
+		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
+		request := models.FundraisingByCongressionalCommitteeRequest{Committee: "HARM"}
+		_, err := client.GetCommitteeFundraisingDetails(request)
+		test.AssertErrorExists(err, t)
+	})
+}
+
 func TestMakeGETRequest(t *testing.T) {
 	t.Run("Returns an error if the HTTP call fails", func(t *testing.T) {
 		mockError := errors.New("fail")

--- a/pkg/client/url.go
+++ b/pkg/client/url.go
@@ -9,11 +9,11 @@ import (
 
 const baseUrl string = "http://www.opensecrets.org/api/"
 
-func buildGetLegislatorsURL(request models.GetLegislatorsRequest, apiKey string) string {
+func buildGetLegislatorsURL(request models.LegislatorsRequest, apiKey string) string {
 	return baseUrl + "?method=getLegislators&output=json&apikey=" + apiKey + "&id=" + request.Id
 }
 
-func buildGetMemberPFDURL(request models.GetMemberPFDRequest, apiKey string) string {
+func buildGetMemberPFDURL(request models.MemberPFDRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=memPFDProfile&output=json&apikey=" + apiKey + "&cid=" + request.Cid)
 
@@ -25,7 +25,7 @@ func buildGetMemberPFDURL(request models.GetMemberPFDRequest, apiKey string) str
 	return builder.String()
 }
 
-func buildGetCandidateSummaryURL(request models.GetCandidateSummaryRequest, apiKey string) string {
+func buildGetCandidateSummaryURL(request models.CandidateSummaryRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=candSummary&output=json&apikey=" + apiKey + "&cid=" + request.Cid)
 
@@ -37,7 +37,7 @@ func buildGetCandidateSummaryURL(request models.GetCandidateSummaryRequest, apiK
 	return builder.String()
 }
 
-func buildGetCandidateContributorsURL(request models.GetCandidateContributorsRequest, apiKey string) string {
+func buildGetCandidateContributorsURL(request models.CandidateContributorsRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=candContrib&output=json&apikey=" + apiKey + "&cid=" + request.Cid)
 
@@ -49,7 +49,7 @@ func buildGetCandidateContributorsURL(request models.GetCandidateContributorsReq
 	return builder.String()
 }
 
-func buildGetCandidateIndustriesURL(request models.GetCandidateIndustriesRequest, apiKey string) string {
+func buildGetCandidateIndustriesURL(request models.CandidateIndustriesRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=candIndustry&output=json&apikey=" + apiKey + "&cid=" + request.Cid)
 
@@ -61,7 +61,7 @@ func buildGetCandidateIndustriesURL(request models.GetCandidateIndustriesRequest
 	return builder.String()
 }
 
-func buildGetCandidateIndustryDetailsURL(request models.GetCandidateIndustryDetailsRequest, apiKey string) string {
+func buildGetCandidateIndustryDetailsURL(request models.CandidateIndustryDetailsRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=candIndByInd&output=json&apikey=" + apiKey + "&cid=" + request.Cid + "&ind=" + request.Ind)
 
@@ -73,7 +73,7 @@ func buildGetCandidateIndustryDetailsURL(request models.GetCandidateIndustryDeta
 	return builder.String()
 }
 
-func buildGetCandidatTopSectorsURL(request models.GetCandidateTopSectorsRequest, apiKey string) string {
+func buildGetCandidatTopSectorsURL(request models.CandidateTopSectorsRequest, apiKey string) string {
 	var builder strings.Builder
 	builder.WriteString(baseUrl + "?method=candSector&output=json&apikey=" + apiKey + "&cid=" + request.Cid)
 

--- a/pkg/client/url.go
+++ b/pkg/client/url.go
@@ -84,3 +84,15 @@ func buildGetCandidatTopSectorsURL(request models.GetCandidateTopSectorsRequest,
 
 	return builder.String()
 }
+
+func buildFundraisingByCongressionalCommitteeRequestURL(request models.FundraisingByCongressionalCommitteeRequest, apiKey string) string {
+	var builder strings.Builder
+	builder.WriteString(baseUrl + "?method=congCmteIndus&output=json&apikey=" + apiKey + "&cmte=" + request.Committee + "&indus=" + request.Industry)
+
+	if request.CongressNumber != 0 {
+		builder.WriteString("&congno=")
+		builder.WriteString(strconv.Itoa(request.CongressNumber))
+	}
+
+	return builder.String()
+}

--- a/pkg/client/url_test.go
+++ b/pkg/client/url_test.go
@@ -12,7 +12,7 @@ const apiKey string = "1"
 func TestBuildGetLegislatorsURL(t *testing.T) {
 	t.Run("Includes id passed in with request", func(t *testing.T) {
 		id := "NJ"
-		url := buildGetLegislatorsURL(models.GetLegislatorsRequest{Id: id}, apiKey)
+		url := buildGetLegislatorsURL(models.LegislatorsRequest{Id: id}, apiKey)
 		expectedUrl := baseUrl + "?method=getLegislators&output=json&apikey=" + apiKey + "&id=" + id
 		test.AssertStringMatches(url, expectedUrl, t)
 	})
@@ -21,7 +21,7 @@ func TestBuildGetLegislatorsURL(t *testing.T) {
 func TestBuildGetMemberPFDURL(t *testing.T) {
 	t.Run("Includes cid passed in request", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetMemberPFDRequest{Cid: cid}
+		request := models.MemberPFDRequest{Cid: cid}
 		url := buildGetMemberPFDURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=memPFDProfile&output=json&apikey=" + apiKey + "&cid=" + cid
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -29,7 +29,7 @@ func TestBuildGetMemberPFDURL(t *testing.T) {
 	t.Run("Includes year passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
 		year := 2020
-		request := models.GetMemberPFDRequest{Cid: cid, Year: year}
+		request := models.MemberPFDRequest{Cid: cid, Year: year}
 		url := buildGetMemberPFDURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=memPFDProfile&output=json&apikey=" + apiKey + "&cid=" + cid + "&year=2020"
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -39,7 +39,7 @@ func TestBuildGetMemberPFDURL(t *testing.T) {
 func TestBuildGetCandidateSummaryURL(t *testing.T) {
 	t.Run("Includes cid passed in request", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateSummaryRequest{Cid: cid}
+		request := models.CandidateSummaryRequest{Cid: cid}
 		url := buildGetCandidateSummaryURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candSummary&output=json&apikey=" + apiKey + "&cid=" + cid
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -47,7 +47,7 @@ func TestBuildGetCandidateSummaryURL(t *testing.T) {
 	t.Run("Includes cycle passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
 		cycle := 2020
-		request := models.GetCandidateSummaryRequest{Cid: cid, Cycle: cycle}
+		request := models.CandidateSummaryRequest{Cid: cid, Cycle: cycle}
 		url := buildGetCandidateSummaryURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candSummary&output=json&apikey=" + apiKey + "&cid=" + cid + "&cycle=2020"
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -57,7 +57,7 @@ func TestBuildGetCandidateSummaryURL(t *testing.T) {
 func TestBuildGetCandidateContributorsURL(t *testing.T) {
 	t.Run("Includes cid passed in request", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateContributorsRequest{Cid: cid}
+		request := models.CandidateContributorsRequest{Cid: cid}
 		url := buildGetCandidateContributorsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candContrib&output=json&apikey=" + apiKey + "&cid=" + cid
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -65,7 +65,7 @@ func TestBuildGetCandidateContributorsURL(t *testing.T) {
 	t.Run("Includes cycle passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
 		cycle := 2022
-		request := models.GetCandidateContributorsRequest{Cid: cid, Cycle: cycle}
+		request := models.CandidateContributorsRequest{Cid: cid, Cycle: cycle}
 		url := buildGetCandidateContributorsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candContrib&output=json&apikey=" + apiKey + "&cid=" + cid + "&cycle=2022"
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -75,14 +75,14 @@ func TestBuildGetCandidateContributorsURL(t *testing.T) {
 func TestBuildGetCandidateIndustriesURL(t *testing.T) {
 	t.Run("Includes cid passed in request", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateIndustriesRequest{Cid: cid}
+		request := models.CandidateIndustriesRequest{Cid: cid}
 		url := buildGetCandidateIndustriesURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candIndustry&output=json&apikey=" + apiKey + "&cid=" + cid
 		test.AssertStringMatches(url, expectedUrl, t)
 	})
 	t.Run("Includes cycle passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateIndustriesRequest{Cid: cid, Cycle: 2018}
+		request := models.CandidateIndustriesRequest{Cid: cid, Cycle: 2018}
 		url := buildGetCandidateIndustriesURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candIndustry&output=json&apikey=" + apiKey + "&cid=" + cid + "&cycle=2018"
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -93,7 +93,7 @@ func TestBuildGetCandidateIndustryDetailsURL(t *testing.T) {
 	t.Run("Includes cid and industry code passed in requerst", func(t *testing.T) {
 		cid := "N00007360"
 		industryCode := "K02"
-		request := models.GetCandidateIndustryDetailsRequest{Cid: cid, Ind: industryCode}
+		request := models.CandidateIndustryDetailsRequest{Cid: cid, Ind: industryCode}
 		url := buildGetCandidateIndustryDetailsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candIndByInd&output=json&apikey=" + apiKey + "&cid=" + cid + "&ind=" + industryCode
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -101,7 +101,7 @@ func TestBuildGetCandidateIndustryDetailsURL(t *testing.T) {
 	t.Run("Includes cycle passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
 		industryCode := "K02"
-		request := models.GetCandidateIndustryDetailsRequest{Cid: cid, Ind: industryCode, Cycle: 2020}
+		request := models.CandidateIndustryDetailsRequest{Cid: cid, Ind: industryCode, Cycle: 2020}
 		url := buildGetCandidateIndustryDetailsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candIndByInd&output=json&apikey=" + apiKey + "&cid=" + cid + "&ind=" + industryCode + "&cycle=2020"
 		test.AssertStringMatches(url, expectedUrl, t)
@@ -111,14 +111,14 @@ func TestBuildGetCandidateIndustryDetailsURL(t *testing.T) {
 func TestBuildGetCandidateTopSectorsURL(t *testing.T) {
 	t.Run("Includes cid passed in request", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateTopSectorsRequest{Cid: cid}
+		request := models.CandidateTopSectorsRequest{Cid: cid}
 		url := buildGetCandidatTopSectorsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candSector&output=json&apikey=" + apiKey + "&cid=" + cid
 		test.AssertStringMatches(url, expectedUrl, t)
 	})
 	t.Run("Includes cycle passed in request if it's a non-zero value", func(t *testing.T) {
 		cid := "N00007360"
-		request := models.GetCandidateTopSectorsRequest{Cid: cid, Cycle: 2020}
+		request := models.CandidateTopSectorsRequest{Cid: cid, Cycle: 2020}
 		url := buildGetCandidatTopSectorsURL(request, apiKey)
 		expectedUrl := baseUrl + "?method=candSector&output=json&apikey=" + apiKey + "&cid=" + cid + "&cycle=2020"
 		test.AssertStringMatches(url, expectedUrl, t)

--- a/pkg/client/url_test.go
+++ b/pkg/client/url_test.go
@@ -124,3 +124,23 @@ func TestBuildGetCandidateTopSectorsURL(t *testing.T) {
 		test.AssertStringMatches(url, expectedUrl, t)
 	})
 }
+
+func TestBuildFundraisingByCongressionalCommitteeRequestURL(t *testing.T) {
+	t.Run("Includes committee ID and industry code passed in request", func(t *testing.T) {
+		committeeId := "HARM"
+		industryCode := "F10"
+		request := models.FundraisingByCongressionalCommitteeRequest{Committee: committeeId, Industry: industryCode}
+		url := buildFundraisingByCongressionalCommitteeRequestURL(request, apiKey)
+		expectedUrl := baseUrl + "?method=congCmteIndus&output=json&apikey=" + apiKey + "&cmte=" + committeeId + "&indus=" + industryCode
+		test.AssertStringMatches(url, expectedUrl, t)
+	})
+	t.Run("Includes congress number passed in request if it's a non-zero value", func(t *testing.T) {
+		committeeId := "HARM"
+		industryCode := "F10"
+		congressNumber := 116
+		request := models.FundraisingByCongressionalCommitteeRequest{Committee: committeeId, Industry: industryCode, CongressNumber: congressNumber}
+		url := buildFundraisingByCongressionalCommitteeRequestURL(request, apiKey)
+		expectedUrl := baseUrl + "?method=congCmteIndus&output=json&apikey=" + apiKey + "&cmte=" + committeeId + "&indus=" + industryCode + "&congno=116"
+		test.AssertStringMatches(url, expectedUrl, t)
+	})
+}

--- a/pkg/models/candidate_summary.go
+++ b/pkg/models/candidate_summary.go
@@ -1,6 +1,6 @@
 package models
 
-// Summary fundraising information for a poitician.
+// Summary fundraising information for a politician.
 type CandidateSummary struct {
 	CandidateName string  `json:"cand_name"`
 	Cid           string  `json:"cid"` // CRP ID

--- a/pkg/models/committee_fundraising.go
+++ b/pkg/models/committee_fundraising.go
@@ -1,0 +1,23 @@
+package models
+
+// Summary fundraising information for a congressional committee.
+type CommitteeFundraisingDetails struct {
+	CommitteeName  string `json:"committee_name"`
+	Industry       string `json:"industry"` // The name of the industry
+	CongressNumber int    `json:"congno,string"`
+	Origin         string `json:"origin"`       // Attribution to display
+	Source         string `json:"source"`       // Link to CRP data
+	LastUpdated    string `json:"last_updated"` // Date data was last retrieved from government sources (MM/DD/YYYY)
+	Members        []CommitteeMember
+}
+
+// Details on a member of a congressional committee
+type CommitteeMember struct {
+	Name        string  `json:"member_name"`
+	Cid         string  `json:"cid"`           // CRP ID
+	Party       string  `json:"party"`         // D, R, 3, L, U for Dem, Repub, 3rd party, Libertarian, Unknown
+	State       string  `json:"state"`         // Full state name
+	Total       float64 `json:"total,string"`  // Total from all itemized sources in the industry
+	Pacs        float64 `json:"pacs,string"`   // Total PAC contributions from the industry
+	Individuals float64 `json:"indivs,string"` // Total individual contributions from the industry
+}

--- a/pkg/models/requests.go
+++ b/pkg/models/requests.go
@@ -1,36 +1,36 @@
 package models
 
-type GetLegislatorsRequest struct {
+type LegislatorsRequest struct {
 	Id string `validate:"required"` // Required. Two-character specific state code, or CRP candidate ID.
 }
 
-type GetMemberPFDRequest struct {
+type MemberPFDRequest struct {
 	Cid  string `validate:"required"` // Required. CRP Candidate ID.
 	Year int    // Optional. 2013, 2014, 2015 and 2016 data provided where available.
 }
 
-type GetCandidateSummaryRequest struct {
+type CandidateSummaryRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID.
 	Cycle int    // Optional; defaults to most recent cycle
 }
 
-type GetCandidateContributorsRequest struct {
+type CandidateContributorsRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID.
 	Cycle int    // Optional; defaults to most recent cycle
 }
 
-type GetCandidateIndustriesRequest struct {
+type CandidateIndustriesRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID
 	Cycle int    // Optional; defaults to most recent cycle
 }
 
-type GetCandidateIndustryDetailsRequest struct {
+type CandidateIndustryDetailsRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID
 	Ind   string `validate:"required"` // Required. A 3-character industry code
 	Cycle int    // Optional; defaults to most recent cycle
 }
 
-type GetCandidateTopSectorsRequest struct {
+type CandidateTopSectorsRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID
 	Cycle int    // Optional; defaults to most recent cycle
 }

--- a/pkg/models/requests.go
+++ b/pkg/models/requests.go
@@ -34,3 +34,9 @@ type GetCandidateTopSectorsRequest struct {
 	Cid   string `validate:"required"` // Required. CRP Candidate ID
 	Cycle int    // Optional; defaults to most recent cycle
 }
+
+type FundraisingByCongressionalCommitteeRequest struct {
+	Committee      string `validate:"required"` // Required. Committee ID in CQ format
+	Industry       string `validate:"required"` // Required. Industry code
+	CongressNumber int    // Optional, defaults to most recent Congress
+}


### PR DESCRIPTION
- Adds a method to call [the `congCmteIndus` endpoint](https://www.opensecrets.org/api/?method=congCmteIndus&output=doc)
- Drops `Get` from the name of all request structs (it's redundant)
- Adds + uses a helper method for checking float values