### PR TITLE
v2.0.0: use context in all public client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ The `OpenSecretsClient` is thread safe; you should construct one and share it th
 
 ### Making API calls
 
-The client has public methods for [each of the OpenSecrets API methods](https://www.opensecrets.org/open-data/api-documentation). To call one, just pass it the appropriate request object from the `models` package:
+The client has public methods for [each of the OpenSecrets API methods](https://www.opensecrets.org/open-data/api-documentation). To call one, just pass it a `context.Contexrt` and the appropriate request object from the `models` package:
 
 ```go
 request := models.LegislatorsRequest{Id: "TX"}
-legislators, err := client.GetLegislators(request)
+legislators, err := client.GetLegislators(context.Background(), request)
 ```
 
 The client will either return a struct containing the data from the API call or an error if something went wrong.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,14 @@
 module github.com/KiaFarhang/opensecrets
 
-go 1.15
+go 1.18
 
 require github.com/go-playground/validator/v10 v10.10.0
+
+require (
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	golang.org/x/text v0.3.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -12,11 +12,9 @@ github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
@@ -24,7 +22,6 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -44,7 +41,6 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -97,7 +97,7 @@ func (o *openSecretsClient) GetLegislators(request models.LegislatorsRequest) ([
 	}
 	url := buildLegislatorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (o *openSecretsClient) GetMemberPFDProfile(request models.MemberPFDRequest)
 
 	url := buildMemberPFDURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.MemberProfile{}, err
@@ -133,7 +133,7 @@ func (o *openSecretsClient) GetCandidateSummary(request models.CandidateSummaryR
 
 	url := buildCandidateSummaryURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CandidateSummary{}, nil
@@ -151,7 +151,7 @@ func (o *openSecretsClient) GetCandidateContributors(request models.CandidateCon
 
 	url := buildCandidateContributorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CandidateContributorSummary{}, err
@@ -169,7 +169,7 @@ func (o *openSecretsClient) GetCandidateIndustries(request models.CandidateIndus
 
 	url := buildGetCandidateIndustriesURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CandidateIndustriesSummary{}, err
@@ -187,7 +187,7 @@ func (o *openSecretsClient) GetCandidateIndustryDetails(request models.Candidate
 
 	url := buildCandidateIndustryDetailsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CandidateIndustryDetails{}, err
@@ -205,7 +205,7 @@ func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.Candidat
 
 	url := buildCandidateTopSectorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CandidateTopSectorDetails{}, err
@@ -223,7 +223,7 @@ func (o *openSecretsClient) GetCommitteeFundraisingDetails(request models.Fundra
 
 	url := buildFundraisingByCongressionalCommitteeRequestURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.CommitteeFundraisingDetails{}, err
@@ -241,7 +241,7 @@ func (o *openSecretsClient) SearchForOrganization(request models.OrganizationSea
 
 	url := buildOrganizationSearchURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return []models.OrganizationSearchResult{}, err
@@ -259,7 +259,7 @@ func (o *openSecretsClient) GetOrganizationSummary(request models.OrganizationSu
 
 	url := buildOrganizationSummaryURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return models.OrganizationSummary{}, err
@@ -271,7 +271,7 @@ func (o *openSecretsClient) GetOrganizationSummary(request models.OrganizationSu
 func (o *openSecretsClient) GetLatestIndependentExpenditures() ([]models.IndependentExpenditure, error) {
 	url := buildIndependentExpendituresURL(o.apiKey)
 
-	responseBody, err := o.makeGETRequest(url)
+	responseBody, err := o.makeGETRequest(context.TODO(), url)
 
 	if err != nil {
 		return []models.IndependentExpenditure{}, err
@@ -280,37 +280,7 @@ func (o *openSecretsClient) GetLatestIndependentExpenditures() ([]models.Indepen
 	return parse.ParseIndependentExpendituresJSON(responseBody)
 }
 
-func (o *openSecretsClient) makeGETRequest(url string) ([]byte, error) {
-	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// The API blocks requests without a user agent
-	request.Header.Set("User-Agent", "Golang")
-
-	response, err := o.client.Do(request)
-
-	if err != nil {
-		return nil, err
-	}
-
-	statusCode := response.StatusCode
-
-	if statusCode >= 400 {
-		return nil, fmt.Errorf("received %d status code calling OpenSecrets API", statusCode)
-	}
-
-	bodyAsBytes, err := io.ReadAll(response.Body)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return bodyAsBytes, nil
-}
-
-func (o *openSecretsClient) makeGETRequestWithContext(ctx context.Context, url string) ([]byte, error) {
+func (o *openSecretsClient) makeGETRequest(ctx context.Context, url string) ([]byte, error) {
 	request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,37 +24,37 @@ An OpenSecretsClient is thread safe and you should use/share one throughout your
 type OpenSecretsClient interface {
 	// Provides a list of Congressional legislators for a specified subset (state or specific CID)
 	// https://www.opensecrets.org/api/?method=getLegislators&output=doc
-	GetLegislators(request models.LegislatorsRequest) ([]models.Legislator, error)
+	GetLegislators(ctx context.Context, request models.LegislatorsRequest) ([]models.Legislator, error)
 	// Returns data on the personal finances of a member of Congress, as well as judicial + executive branches
 	// https://www.opensecrets.org/api/?method=memPFDprofile&output=doc
-	GetMemberPFDProfile(request models.MemberPFDRequest) (models.MemberProfile, error)
+	GetMemberPFDProfile(ctx context.Context, request models.MemberPFDRequest) (models.MemberProfile, error)
 	// Provides summary fundraising information for a politician
 	// https://www.opensecrets.org/api/?method=candSummary&output=doc
-	GetCandidateSummary(request models.CandidateSummaryRequest) (models.CandidateSummary, error)
+	GetCandidateSummary(ctx context.Context, request models.CandidateSummaryRequest) (models.CandidateSummary, error)
 	// Returns top contributors to a candidate for/sitting member of Congress
 	// https://www.opensecrets.org/api/?method=candContrib&output=doc
-	GetCandidateContributors(request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error)
+	GetCandidateContributors(ctx context.Context, request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error)
 	// Provides the top 10 industries contributing to a candidate
 	// https://www.opensecrets.org/api/?method=candIndustry&output=doc
-	GetCandidateIndustries(request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error)
+	GetCandidateIndustries(ctx context.Context, request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error)
 	// Provides total contributed to a candidate from an industry.
 	// https://www.opensecrets.org/api/?method=candIndByInd&output=doc
-	GetCandidateIndustryDetails(request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error)
+	GetCandidateIndustryDetails(ctx context.Context, request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error)
 	// Provides sector total of a candidate's receipts
 	// https://www.opensecrets.org/api/?method=candSector&output=doc
-	GetCandidateTopSectorDetails(request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error)
+	GetCandidateTopSectorDetails(ctx context.Context, request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error)
 	// Provides fundraising details for all members of a given committee from the provided industry
 	// https://www.opensecrets.org/api/?method=congCmteIndus&output=doc
-	GetCommitteeFundraisingDetails(request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error)
+	GetCommitteeFundraisingDetails(ctx context.Context, request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error)
 	// Searches for an organization by name or partial name
 	// https://www.opensecrets.org/api/?method=getOrgs&output=doc
-	SearchForOrganization(request models.OrganizationSearch) ([]models.OrganizationSearchResult, error)
+	SearchForOrganization(ctx context.Context, request models.OrganizationSearch) ([]models.OrganizationSearchResult, error)
 	// Provides summary fundraising information for an organization
 	// https://www.opensecrets.org/api/?method=orgSummary&output=doc
-	GetOrganizationSummary(request models.OrganizationSummaryRequest) (models.OrganizationSummary, error)
+	GetOrganizationSummary(ctx context.Context, request models.OrganizationSummaryRequest) (models.OrganizationSummary, error)
 	// Provides the latest 50 independent expenditure transactions reported. Updated 4 times a day.
 	// https://www.opensecrets.org/api/?method=independentExpend&output=doc
-	GetLatestIndependentExpenditures() ([]models.IndependentExpenditure, error)
+	GetLatestIndependentExpenditures(ctx context.Context) ([]models.IndependentExpenditure, error)
 }
 
 /*
@@ -88,7 +88,7 @@ func NewOpenSecretsClientWithHttpClient(apikey string, client OpenSecretsHttpCli
 	return &openSecretsClient{apiKey: apikey, client: client, validator: validator.New()}
 }
 
-func (o *openSecretsClient) GetLegislators(request models.LegislatorsRequest) ([]models.Legislator, error) {
+func (o *openSecretsClient) GetLegislators(ctx context.Context, request models.LegislatorsRequest) ([]models.Legislator, error) {
 
 	err := o.validator.Struct(request)
 
@@ -97,7 +97,7 @@ func (o *openSecretsClient) GetLegislators(request models.LegislatorsRequest) ([
 	}
 	url := buildLegislatorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (o *openSecretsClient) GetLegislators(request models.LegislatorsRequest) ([
 	return parse.ParseLegislatorsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetMemberPFDProfile(request models.MemberPFDRequest) (models.MemberProfile, error) {
+func (o *openSecretsClient) GetMemberPFDProfile(ctx context.Context, request models.MemberPFDRequest) (models.MemberProfile, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -115,7 +115,7 @@ func (o *openSecretsClient) GetMemberPFDProfile(request models.MemberPFDRequest)
 
 	url := buildMemberPFDURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.MemberProfile{}, err
@@ -124,7 +124,7 @@ func (o *openSecretsClient) GetMemberPFDProfile(request models.MemberPFDRequest)
 	return parse.ParseMemberPFDJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateSummary(request models.CandidateSummaryRequest) (models.CandidateSummary, error) {
+func (o *openSecretsClient) GetCandidateSummary(ctx context.Context, request models.CandidateSummaryRequest) (models.CandidateSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -133,7 +133,7 @@ func (o *openSecretsClient) GetCandidateSummary(request models.CandidateSummaryR
 
 	url := buildCandidateSummaryURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CandidateSummary{}, nil
@@ -142,7 +142,7 @@ func (o *openSecretsClient) GetCandidateSummary(request models.CandidateSummaryR
 	return parse.ParseCandidateSummaryJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateContributors(request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error) {
+func (o *openSecretsClient) GetCandidateContributors(ctx context.Context, request models.CandidateContributorsRequest) (models.CandidateContributorSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -151,7 +151,7 @@ func (o *openSecretsClient) GetCandidateContributors(request models.CandidateCon
 
 	url := buildCandidateContributorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CandidateContributorSummary{}, err
@@ -160,7 +160,7 @@ func (o *openSecretsClient) GetCandidateContributors(request models.CandidateCon
 	return parse.ParseCandidateContributorsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateIndustries(request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error) {
+func (o *openSecretsClient) GetCandidateIndustries(ctx context.Context, request models.CandidateIndustriesRequest) (models.CandidateIndustriesSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -169,7 +169,7 @@ func (o *openSecretsClient) GetCandidateIndustries(request models.CandidateIndus
 
 	url := buildGetCandidateIndustriesURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CandidateIndustriesSummary{}, err
@@ -178,7 +178,7 @@ func (o *openSecretsClient) GetCandidateIndustries(request models.CandidateIndus
 	return parse.ParseCandidateIndustriesJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateIndustryDetails(request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error) {
+func (o *openSecretsClient) GetCandidateIndustryDetails(ctx context.Context, request models.CandidateIndustryDetailsRequest) (models.CandidateIndustryDetails, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -187,7 +187,7 @@ func (o *openSecretsClient) GetCandidateIndustryDetails(request models.Candidate
 
 	url := buildCandidateIndustryDetailsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CandidateIndustryDetails{}, err
@@ -196,7 +196,7 @@ func (o *openSecretsClient) GetCandidateIndustryDetails(request models.Candidate
 	return parse.ParseCandidateIndustryDetailsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error) {
+func (o *openSecretsClient) GetCandidateTopSectorDetails(ctx context.Context, request models.CandidateTopSectorsRequest) (models.CandidateTopSectorDetails, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -205,7 +205,7 @@ func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.Candidat
 
 	url := buildCandidateTopSectorsURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CandidateTopSectorDetails{}, err
@@ -214,7 +214,7 @@ func (o *openSecretsClient) GetCandidateTopSectorDetails(request models.Candidat
 	return parse.ParseCandidateTopSectorsJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetCommitteeFundraisingDetails(request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error) {
+func (o *openSecretsClient) GetCommitteeFundraisingDetails(ctx context.Context, request models.FundraisingByCongressionalCommitteeRequest) (models.CommitteeFundraisingDetails, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -223,7 +223,7 @@ func (o *openSecretsClient) GetCommitteeFundraisingDetails(request models.Fundra
 
 	url := buildFundraisingByCongressionalCommitteeRequestURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.CommitteeFundraisingDetails{}, err
@@ -232,7 +232,7 @@ func (o *openSecretsClient) GetCommitteeFundraisingDetails(request models.Fundra
 	return parse.ParseFundraisingByCommitteeJSON(responseBody)
 }
 
-func (o *openSecretsClient) SearchForOrganization(request models.OrganizationSearch) ([]models.OrganizationSearchResult, error) {
+func (o *openSecretsClient) SearchForOrganization(ctx context.Context, request models.OrganizationSearch) ([]models.OrganizationSearchResult, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -241,7 +241,7 @@ func (o *openSecretsClient) SearchForOrganization(request models.OrganizationSea
 
 	url := buildOrganizationSearchURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return []models.OrganizationSearchResult{}, err
@@ -250,7 +250,7 @@ func (o *openSecretsClient) SearchForOrganization(request models.OrganizationSea
 	return parse.ParseOrganizationSearchJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetOrganizationSummary(request models.OrganizationSummaryRequest) (models.OrganizationSummary, error) {
+func (o *openSecretsClient) GetOrganizationSummary(ctx context.Context, request models.OrganizationSummaryRequest) (models.OrganizationSummary, error) {
 	err := o.validator.Struct(request)
 
 	if err != nil {
@@ -259,7 +259,7 @@ func (o *openSecretsClient) GetOrganizationSummary(request models.OrganizationSu
 
 	url := buildOrganizationSummaryURL(request, o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return models.OrganizationSummary{}, err
@@ -268,10 +268,10 @@ func (o *openSecretsClient) GetOrganizationSummary(request models.OrganizationSu
 	return parse.ParseOrganizationSummaryJSON(responseBody)
 }
 
-func (o *openSecretsClient) GetLatestIndependentExpenditures() ([]models.IndependentExpenditure, error) {
+func (o *openSecretsClient) GetLatestIndependentExpenditures(ctx context.Context) ([]models.IndependentExpenditure, error) {
 	url := buildIndependentExpendituresURL(o.apiKey)
 
-	responseBody, err := o.makeGETRequest(context.TODO(), url)
+	responseBody, err := o.makeGETRequest(ctx, url)
 
 	if err != nil {
 		return []models.IndependentExpenditure{}, err

--- a/pkg/client/client_end_to_end_test.go
+++ b/pkg/client/client_end_to_end_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -27,7 +28,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetLegislators", func(t *testing.T) {
 		request := models.LegislatorsRequest{Id: "TX"}
-		legislators, err := client.GetLegislators(request)
+		legislators, err := client.GetLegislators(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetLegislators", err.Error())
 		}
@@ -41,7 +42,7 @@ func TestClientEndToEnd(t *testing.T) {
 	t.Run("GetMemberPFDProfile", func(t *testing.T) {
 		request := models.MemberPFDRequest{Cid: "N00007360", Year: 2016}
 
-		memberProfile, err := client.GetMemberPFDProfile(request)
+		memberProfile, err := client.GetMemberPFDProfile(context.Background(), request)
 
 		if err != nil {
 			t.Fatalf("Got error %s calling GetMemberPFDProfile", err.Error())
@@ -68,7 +69,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCandidateSummary", func(t *testing.T) {
 		request := models.CandidateSummaryRequest{Cid: "N00007360", Cycle: 2022}
-		candidateSummary, err := client.GetCandidateSummary(request)
+		candidateSummary, err := client.GetCandidateSummary(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateSummary", err.Error())
 		}
@@ -80,7 +81,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCandidateContributors", func(t *testing.T) {
 		request := models.CandidateContributorsRequest{Cid: "N00007360", Cycle: 2018}
-		candidateContributorSummary, err := client.GetCandidateContributors(request)
+		candidateContributorSummary, err := client.GetCandidateContributors(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateContributors", err.Error())
 		}
@@ -91,7 +92,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCandidateIndustries", func(t *testing.T) {
 		request := models.CandidateIndustriesRequest{Cid: "N00005681", Cycle: 2018}
-		summary, err := client.GetCandidateIndustries(request)
+		summary, err := client.GetCandidateIndustries(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateIndustries", err.Error())
 		}
@@ -102,7 +103,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCandidateIndustryDetails", func(t *testing.T) {
 		request := models.CandidateIndustryDetailsRequest{Cid: "N00007360", Ind: "K02", Cycle: 2020}
-		details, err := client.GetCandidateIndustryDetails(request)
+		details, err := client.GetCandidateIndustryDetails(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateIndustryDetails", err.Error())
 		}
@@ -113,7 +114,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCandidateTopSectorDetails", func(t *testing.T) {
 		request := models.CandidateTopSectorsRequest{Cid: "N00007360", Cycle: 2020}
-		details, err := client.GetCandidateTopSectorDetails(request)
+		details, err := client.GetCandidateTopSectorDetails(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s calling GetCandidateTopSectorDetails", err.Error())
 		}
@@ -130,7 +131,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetCommitteeFundraisingDetails", func(t *testing.T) {
 		request := models.FundraisingByCongressionalCommitteeRequest{Committee: "HARM", Industry: "F10", CongressNumber: 116}
-		details, err := client.GetCommitteeFundraisingDetails(request)
+		details, err := client.GetCommitteeFundraisingDetails(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Got error %s when calling GetCommitteeFundraisingDetails", err.Error())
 		}
@@ -145,7 +146,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("SearchForOrganization", func(t *testing.T) {
 		request := models.OrganizationSearch{Name: "Goldman"}
-		searchResults, err := client.SearchForOrganization(request)
+		searchResults, err := client.SearchForOrganization(context.Background(), request)
 
 		if err != nil {
 			t.Fatalf("Got error %s when calling SearchForOrganization", err.Error())
@@ -158,7 +159,7 @@ func TestClientEndToEnd(t *testing.T) {
 
 	t.Run("GetOrganizationSummary", func(t *testing.T) {
 		request := models.OrganizationSummaryRequest{Id: "D000000125"}
-		summary, err := client.GetOrganizationSummary(request)
+		summary, err := client.GetOrganizationSummary(context.Background(), request)
 
 		if err != nil {
 			t.Fatalf("Got error %s when calling GetOrganizationSummary", err.Error())
@@ -168,7 +169,7 @@ func TestClientEndToEnd(t *testing.T) {
 	})
 
 	t.Run("GetLatestIndependentExpenditures", func(t *testing.T) {
-		expenditures, err := client.GetLatestIndependentExpenditures()
+		expenditures, err := client.GetLatestIndependentExpenditures(context.Background())
 
 		if err != nil {
 			t.Fatalf("Got error %s when calling GetLatestIndependentExpenditures", err.Error())

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -159,9 +159,6 @@ func TestMakeGETRequest(t *testing.T) {
 		wantedErrorMessage := parse.UnableToParseErrorMessage
 		test.AssertErrorMessage(err, wantedErrorMessage, t)
 	})
-}
-
-func TestMakeGetRequestWithContext(t *testing.T) {
 	t.Run("returns an error if the context passed is canceled before the request completes", func(t *testing.T) {
 		if testing.Short() {
 			t.Skip()
@@ -180,7 +177,7 @@ func TestMakeGetRequestWithContext(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
-		_, err := openSecretsClient.makeGETRequestWithContext(ctx, testServer.URL)
+		_, err := openSecretsClient.makeGETRequest(ctx, testServer.URL)
 
 		test.AssertErrorExists(err, t)
 		if !strings.Contains(err.Error(), "context deadline exceeded") {
@@ -188,6 +185,10 @@ func TestMakeGetRequestWithContext(t *testing.T) {
 		}
 		serverClosed <- true
 	})
+}
+
+func TestMakeGetRequestWithContext(t *testing.T) {
+
 }
 
 func buildMockResponse(statusCode int, jsonBody string) http.Response {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -36,7 +36,7 @@ func TestGetLegislators(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.LegislatorsRequest{}
-		_, err := client.GetLegislators(request)
+		_, err := client.GetLegislators(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -45,7 +45,7 @@ func TestGetMemberPFDProfile(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.MemberPFDRequest{Year: 2020}
-		_, err := client.GetMemberPFDProfile(request)
+		_, err := client.GetMemberPFDProfile(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -54,7 +54,7 @@ func TestGetCandidateSummary(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateSummaryRequest{Cycle: 2022}
-		_, err := client.GetCandidateSummary(request)
+		_, err := client.GetCandidateSummary(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -63,7 +63,7 @@ func TestGetCandidateContributors(t *testing.T) {
 	t.Run("Returns an error if the request passed is invaid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateContributorsRequest{}
-		_, err := client.GetCandidateContributors(request)
+		_, err := client.GetCandidateContributors(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -72,7 +72,7 @@ func TestGetCandidateIndustries(t *testing.T) {
 	t.Run("Returns an error if the request passed is invalid", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateIndustriesRequest{}
-		_, err := client.GetCandidateIndustries(request)
+		_, err := client.GetCandidateIndustries(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -81,13 +81,13 @@ func TestGetCandidateIndustryDetails(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have a CID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateIndustryDetailsRequest{Ind: "K02"}
-		_, err := client.GetCandidateIndustryDetails(request)
+		_, err := client.GetCandidateIndustryDetails(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 	t.Run("Returns an error if the request doesn't have an industry code", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateIndustryDetailsRequest{Cid: "N00007360"}
-		_, err := client.GetCandidateIndustryDetails(request)
+		_, err := client.GetCandidateIndustryDetails(context.Background(), request)
 		test.AssertErrorExists(err, t)
 
 	})
@@ -97,7 +97,7 @@ func TestGetCandidateTopSectorDetails(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have a CID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.CandidateTopSectorsRequest{}
-		_, err := client.GetCandidateTopSectorDetails(request)
+		_, err := client.GetCandidateTopSectorDetails(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -106,13 +106,13 @@ func TestGetCommitteeFundraisingDetails(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have a committee ID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.FundraisingByCongressionalCommitteeRequest{Industry: "ABC"}
-		_, err := client.GetCommitteeFundraisingDetails(request)
+		_, err := client.GetCommitteeFundraisingDetails(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 	t.Run("Returns an error if the request doesn't have an industry ID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.FundraisingByCongressionalCommitteeRequest{Committee: "HARM"}
-		_, err := client.GetCommitteeFundraisingDetails(request)
+		_, err := client.GetCommitteeFundraisingDetails(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -121,7 +121,7 @@ func TestSearchForOrganization(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have an org name", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.OrganizationSearch{}
-		_, err := client.SearchForOrganization(request)
+		_, err := client.SearchForOrganization(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -130,7 +130,7 @@ func TestGetOrganizationSummary(t *testing.T) {
 	t.Run("Returns an error if the request doesn't have an org ID", func(t *testing.T) {
 		client := openSecretsClient{client: &mockHttpClient{}, validator: validator.New()}
 		request := models.OrganizationSummaryRequest{}
-		_, err := client.GetOrganizationSummary(request)
+		_, err := client.GetOrganizationSummary(context.Background(), request)
 		test.AssertErrorExists(err, t)
 	})
 }
@@ -139,14 +139,14 @@ func TestMakeGETRequest(t *testing.T) {
 	t.Run("Returns an error if the HTTP call fails", func(t *testing.T) {
 		mockError := errors.New("fail")
 		client := openSecretsClient{client: &mockHttpClient{mockError: mockError}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.LegislatorsRequest{})
+		_, err := client.GetLegislators(context.Background(), models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		test.AssertErrorMessage(err, "fail", t)
 	})
 	t.Run("Returns an error if the HTTP call is a >= 400 status code", func(t *testing.T) {
 		mockResponse := buildMockResponse(400, "")
 		client := openSecretsClient{client: &mockHttpClient{mockResponse: mockResponse}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.LegislatorsRequest{})
+		_, err := client.GetLegislators(context.Background(), models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		wantedErrorMessage := "received 400 status code calling OpenSecrets API"
 		test.AssertErrorMessage(err, wantedErrorMessage, t)
@@ -154,7 +154,7 @@ func TestMakeGETRequest(t *testing.T) {
 	t.Run("Returns an error if the response body can't be parsed", func(t *testing.T) {
 		mockResponse := buildMockResponse(200, `BAD JSON WEEEE`)
 		client := openSecretsClient{client: &mockHttpClient{mockResponse: mockResponse}, validator: &mockValidator{}}
-		_, err := client.GetLegislators(models.LegislatorsRequest{})
+		_, err := client.GetLegislators(context.Background(), models.LegislatorsRequest{})
 		test.AssertErrorExists(err, t)
 		wantedErrorMessage := parse.UnableToParseErrorMessage
 		test.AssertErrorMessage(err, wantedErrorMessage, t)


### PR DESCRIPTION
- Adds a breaking change to all client methods; they now require a [`context.Context`](https://pkg.go.dev/context#Context) as the first argument to support context-based deadlines and cancellation
- Bumps go version to 1.18